### PR TITLE
ghc 8.2.2 compat, relax time constraint

### DIFF
--- a/robots-txt.cabal
+++ b/robots-txt.cabal
@@ -27,7 +27,7 @@ library
   build-depends:        base >= 4 && <= 5
                       , bytestring
                       , attoparsec >= 0.12.1.6 && < 0.14
-                      , time >= 1.4 && < 1.7
+                      , time >= 1.4 && < 1.9
                       , old-locale >= 1.0.0.5 && < 1.1
 
 test-suite tests

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-6.8
+resolver: lts-10.4
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This is not my patch. :)

However, I respectfully request that @bermanjosh 's GHC 8.2.2 patch relaxing `time` be merged upstream into @meanpath 's, since it solves a dependency incompatibility for me using GHC 8.2.1. `time` resolves as `1.8.0.2` for me; I haven't tried with future times, or GHC 8.2.2 itself. I can't comment on the included Stack change, either, since I don't use it. But I can verify that a program using GHC 8.2.1, `robots 0.4.1.4` compiles with this change.

I believe the licences are compatible. @bermanjosh, if you could confirm and ideally take over the PR yourself, that would be great. :) Otherwise, I am happy to assist where needed.

Peace, tiredpixel