### PR TITLE
build: remove time upper bound, for Haskell 8.8.3

### DIFF
--- a/robots-txt.cabal
+++ b/robots-txt.cabal
@@ -27,7 +27,7 @@ library
   build-depends:        base >= 4 && <= 5
                       , bytestring
                       , attoparsec >= 0.12.1.6 && < 0.14
-                      , time >= 1.4 && < 1.9
+                      , time >= 1.4
                       , old-locale >= 1.0.0.5 && < 1.1
 
 test-suite tests


### PR DESCRIPTION
Similar to #12, the upper bound for time package results in a dependency tree incompatibility when attempting to use from Haskell 8.8.3 (with various other packages also in the tree). I've verified that time 1.9.3 works; time 1.10 is currently the latest, but this hasn't been tested, since it's incompatible with other packages. I'm not aware of any reason why it would be incompatible though, so here we simply remove the upper bound, rather than restrict `<= 1.9.3`, since if an incompatibility is found, it's easy for someone to lock the time package within a project's dependency tree until this package is patched (whereas they can't loosen a restriction).